### PR TITLE
Fix(deps): Update and align dependency versions for compatibility

### DIFF
--- a/Application/gradle/libs.versions.toml
+++ b/Application/gradle/libs.versions.toml
@@ -1,0 +1,32 @@
+[versions]
+agp = "8.3.2"
+kotlin = "1.9.22"
+coreKtx = "1.12.0"
+junit = "4.13.2"
+junitVersion = "1.1.5"
+espressoCore = "3.5.1"
+lifecycleRuntimeKtx = "2.6.1"
+activityCompose = "1.8.0"
+composeBom = "2024.04.01"
+composeCompiler = "1.5.8"
+
+[libraries]
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
This commit corrects the versions of several key dependencies in the `libs.versions.toml` file to ensure compatibility and fix build issues.

The following changes have been made:
- Aligned AGP, Kotlin, and Compose versions to a stable and compatible combination:
  - AGP: 8.3.2
  - Kotlin: 1.9.22
  - Compose Compiler: 1.5.8
- Updated other dependencies to their latest stable versions:
  - Compose BOM: 2024.04.01
  - Espresso Core: 3.5.1
  - AndroidX JUnit: 1.1.5
  - Core KTX: 1.12.0
- Replaced the deprecated `kotlin-stdlib-jdk8` with `kotlin-stdlib`.

**Important:** To complete the fix, you must update your module-level `build.gradle` file to use the new `composeCompiler` version. Add the following to your `android` block:

```groovy
android {
    ...
    composeOptions {
        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
    }
}
```